### PR TITLE
Add Replicate Link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 <h5 align="center">
     
 [![hf_space](https://img.shields.io/badge/🤗-Open%20In%20Spaces-blue.svg)](https://huggingface.co/spaces/LanguageBind/Video-LLaVA)
+[![Replicate demo and cloud API](https://replicate.com/nateraw/video-llava/badge)](https://replicate.com/nateraw/video-llava)
 [![arXiv](https://img.shields.io/badge/Arxiv-2311.10122-b31b1b.svg?logo=arXiv)](https://arxiv.org/abs/2311.10122)
 [![License](https://img.shields.io/badge/License-Apache%202.0-yellow)](https://github.com/PKU-YuanGroup/Video-LLaVA/blob/main/LICENSE)
 [![Hits](https://hits.seeyoufarm.com/api/count/incr/badge.svg?url=https%3A%2F%2Fgithub.com%2FPKU-YuanGroup%2FVideo-LLaVA&count_bg=%2379C83D&title_bg=%23555555&icon=&icon_color=%23E7E7E7&title=Visitor&edge_flat=false)](https://hits.seeyoufarm.com)


### PR DESCRIPTION
Hey there - love this work. Thank you for both sharing and opening up access to this model ❤️

This PR adds a link to a replicate demo for Video-LLaVA that I put together by referencing the HF space. It's currently under my user profile, but I'd be happy to add it under the `PKU-YuanGroup` organization on Replicate if you'd like. I can do this for you - just let me know!

The replicate demo lets folks make predictions in the browser as well as via Node, Python, HTTP requests, etc. Folks can also pull the docker image being served there and run it locally without any other setup.

[![Replicate demo and cloud API](https://replicate.com/nateraw/video-llava/badge)](https://replicate.com/nateraw/video-llava)